### PR TITLE
Added the 'unit' param and adjusted output for expression use.

### DIFF
--- a/src/Audit/FilesystemAnalysis.php
+++ b/src/Audit/FilesystemAnalysis.php
@@ -6,9 +6,28 @@ use Drutiny\Sandbox\Sandbox;
 use Drutiny\Credential\Manager;
 use Drutiny\Acquia\CloudApiDrushAdaptor;
 use Drutiny\Acquia\CloudApiV2;
+use Drutiny\Annotation\Param;
 
 /**
- * Check to ensure Production Mode is enabled on Acquia Cloud.
+ * Audit the usage of the filesystem.
+ *
+ * @Param(
+ *  name = "expression",
+ *  type = "string",
+ *  default = "true",
+ *  description = "The expression language to evaludate. See https://symfony.com/doc/current/components/expression_language/syntax.html"
+ * )
+ * @Param(
+ *  name = "not_applicable",
+ *  type = "string",
+ *  default = "false",
+ *  description = "The expression language to evaludate if the analysis is not applicable. See https://symfony.com/doc/current/components/expression_language/syntax.html"
+ * )
+ * @Param(
+ *  name = "unit",
+ *  description = "the unit of measurement to describe the volume usage in. E.g. B,M,G,T.",
+ *  default = "G"
+ * )
  */
 class FilesystemAnalysis extends EnvironmentAnalysis {
 
@@ -18,16 +37,25 @@ class FilesystemAnalysis extends EnvironmentAnalysis {
   public function gather(Sandbox $sandbox) {
     parent::gather($sandbox);
 
-    $output = $sandbox->exec('df -h | grep gfs');
+    $unit = $sandbox->getParameter('unit', "G");
+
+    // Report file system disk space usage based on the unit
+    $output = $sandbox->exec("df -B$unit | grep gfs");
+
+    // Remove all occurrences the storage unit and % from the output.
+    // This will allow the values to be used in conditional expressions.
+    $output = str_replace([$unit,'%'], '', $output);
+
     list($volume, $capacity, $used, $free, $usage, $mountpoint) = array_values(array_filter(preg_split("/\t|\s/", $output)));
+
     $sandbox->setParameter('filesystem', [
       'volume' => $volume,
-      'capacity' => $capacity,
-      'used' => $used,
-      'free' => $free,
-      'usage' => $usage,
+      'capacity' => (int)$capacity,
+      'used' => (int)$used,
+      'free' => (int)$free,
+      'percent_used' => (int)$usage,
       'mountpoint' => $mountpoint,
+      'unit' => $unit,
     ]);
   }
-
 }


### PR DESCRIPTION
The new `unit` param enables the output to be displayed in bytes, megabytes, gigabytes, etc... 

The filesystem tokens previously had the unit as apart of the value, for example `159G`. This prevented leveraging conditional operators in the expression:

```
filesystem:
    volume: /etc/glusterfs/glusterfs-client.vol
    capacity: 1000G
    used: 159G
    free: 842G
    usage: 16%
    mountpoint: /mnt/gfs
```

The unit and percent sign has been removed from the output and the unit token is now available:
```
filesystem:
    volume: /etc/glusterfs/glusterfs-client.vol
    capacity: 1000
    used: 159
    free: 842
    percent_used: 16
    mountpoint: /mnt/gfs
    unit: G
```