### PR TITLE
Adding the drush target metadata as available variables.

### DIFF
--- a/src/Audit/AppInfo.php
+++ b/src/Audit/AppInfo.php
@@ -21,7 +21,6 @@ class AppInfo extends Audit {
 
     $this->set('app', $app);
 
-
     // $this->set('databases', $client->getApplicationDatabases([
     //   'applicationUuid' => $app['uuid'],
     // ]));

--- a/src/Audit/AppInfo.php
+++ b/src/Audit/AppInfo.php
@@ -17,8 +17,10 @@ class AppInfo extends Audit {
 
     $client = $this->container->get('acquia.cloud.api')->getClient();
     $app = $this->target['acquia.cloud.application']->export();
+    $this->set('drush', $this->target['drush']->export());
 
     $this->set('app', $app);
+
 
     // $this->set('databases', $client->getApplicationDatabases([
     //   'applicationUuid' => $app['uuid'],


### PR DESCRIPTION
This is needed in order to output the Drupal version in a policy. 