### PR TITLE
Adding the acquia.cloud.environment target data to the AppInfo audit class.

### DIFF
--- a/src/Audit/AppInfo.php
+++ b/src/Audit/AppInfo.php
@@ -18,7 +18,7 @@ class AppInfo extends Audit {
     $client = $this->container->get('acquia.cloud.api')->getClient();
     $app = $this->target['acquia.cloud.application']->export();
     $this->set('drush', $this->target['drush']->export());
-
+    $this->set('environment', $this->target['acquia.cloud.environment']->export());
     $this->set('app', $app);
 
     // $this->set('databases', $client->getApplicationDatabases([


### PR DESCRIPTION
Adding the environment data provides access to the VCS info which is needed to display the tag or branch deployed to the environment. 