### PR TITLE
Commenting out log_forwarding_destinations.

### DIFF
--- a/src/Audit/EnvironmentAnalysis.php
+++ b/src/Audit/EnvironmentAnalysis.php
@@ -65,9 +65,9 @@ class EnvironmentAnalysis extends AbstractAnalysis {
         'environmentId' => $environment_id
       ]));
 
-      $this->set('log_forwarding_destinations', $client->getEnvironmentsLogForwardingDestinations([
-        'environmentId' => $environment_id
-      ]));
+      // $this->set('log_forwarding_destinations', $client->getEnvironmentsLogForwardingDestinations([
+      //   'environmentId' => $environment_id
+      // ]));
 
     }
   }


### PR DESCRIPTION
This endpoint has access control that checks to see if a customer has the log forwarding add-on enabled. If log forwarding has not been enabled for this subscription, then all policies that use this class will receive an access denied error. Need to add logic that checks for the entitlement before making the api call.